### PR TITLE
Add method to import objects as entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ covered in the section to follow.
 * `find` - Find Entities by the Component(s) they contain
 * `findAll` - Find ALL Entities contained in the World
 * `findById` - Find a specific Entity by its UUID
+* `loadEntity` - Import an existing object as an Entity in the World
 * `remove` - Remove ALL Entities from the World
 * `removeComponent` - Remove a Component from an Entity
 * `removeEntity` - Remove an Entity from the World
@@ -183,6 +184,27 @@ Example:
     // ... in some other part of the code
     var myDog = world.findById(dogTag);
     // myDog === dog
+
+### loadEntity(object) -> entity
+Import an existing object as an Entity in the World.
+
+* `object`: An object to import as an Entity
+
+This method converts an existing object into an Entity in the World.
+The components are a shallow clone (copied references) of the original
+object. Modification of the original object is not recommended after
+calling `loadEntity`.
+
+If the provided object has a `uuid` property, that UUID will be used
+as the identifier of the Entity in the World. If the provided object
+does not contain a `uuid` property, the World will provide one for
+the newly created Entity.
+
+The Entity created by the world to clone the provided object will
+be returned from the call.
+
+This method is intended for use by serialization frameworks rather
+than applications, so no example is provided.
 
 ### remove() -> World
 Remove all entities from the World.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "index-ecs",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "index-ecs",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Entity-Component-System for Node.js",
     "keywords": [
         "architecture",

--- a/src/main/coffee/ecs.coffee
+++ b/src/main/coffee/ecs.coffee
@@ -112,6 +112,13 @@ class exports.World extends EventEmitter
   findById: (id) ->
     return @index.entities[@index.uuidIndexMap[id]]
 
+  loadEntity: (entity) ->
+    ent = @createEntity entity.uuid
+    for key of entity
+      if key isnt "uuid"
+        @addComponent ent, key, entity[key]
+    return ent
+
   remove: ->
     while @index.entities.length > 0
       @removeEntity _.last @index.entities

--- a/src/test/coffee/ecsTest.coffee
+++ b/src/test/coffee/ecsTest.coffee
@@ -341,5 +341,40 @@ describe "node-ecs", ->
       monsters2.length.should.equal 6
       monsters.should.not.equal monsters2
 
+    describe "loadEntity", ->
+      it "should be able to load an entity without a uuid", ->
+        entity =
+          position:
+            x: 1
+            y: 2
+            z: 3
+          velocity:
+            dx: -1
+            dy: 0
+            dz: +1
+          name:
+            name: "Fred Bloggs"
+        ent = world.loadEntity entity
+        ent.should.have.properties [ "uuid", "position", "velocity", "name" ]
+        entity.uuid = ent.uuid
+        ent.should.eql entity
+
+      it "should be able to load an entity using a uuid", ->
+        entity =
+          uuid: "7df19fa0-4674-49aa-8c28-765ac034978c"
+          position:
+            x: 1
+            y: 2
+            z: 3
+          velocity:
+            dx: -1
+            dy: 0
+            dz: +1
+          name:
+            name: "Fred Bloggs"
+        ent = world.loadEntity entity
+        ent.should.have.properties [ "uuid", "position", "velocity", "name" ]
+        ent.should.eql entity
+
 #----------------------------------------------------------------------
 # end of ecsTest.coffee


### PR DESCRIPTION
`loadEntity` provides a method to restore entities to the world after deserialization.